### PR TITLE
Implement one liner blocks

### DIFF
--- a/src/Modello.php
+++ b/src/Modello.php
@@ -208,7 +208,8 @@ class Modello
     private function handleBlocks(string $page): string
     {
         preg_match_all('/@block\( ?\'(\w*?)\' ?\)(.*?)@endblock/is', $page, $matches, PREG_SET_ORDER);
-        preg_match_all('/@block\( ?\'(\w*?)\', ?\'(\N*?)\' ?\)/is', $page, $matches, PREG_SET_ORDER);
+        preg_match_all('/@block\( ?\'(\w*?)\', ?\'(\N*?)\' ?\)/is', $page, $inlineMatches, PREG_SET_ORDER);
+        $matches = array_merge($matches, $inlineMatches);
 
         foreach ($matches as $match) {
             $this->blocks[$match[1]] = $match[2];

--- a/src/Modello.php
+++ b/src/Modello.php
@@ -16,6 +16,7 @@ class Modello
     private array $handlers = [
         'handleIncludes',
         'handleBlocks',
+        'handleBlockInline',
         'handleHasBlock',
         'handleBlockMissing',
         'handleYields',
@@ -305,6 +306,22 @@ class Modello
         foreach ($matches as $match) {
             $replace = !array_key_exists($match[1], $this->blocks) ? $match[2] : '';
             $page = str_replace($match[0], $replace, $page);
+        }
+
+        return $page;
+    }
+
+    // Directive to do the same thing as @block but in one line with two strings
+    function handleBlockInline(string $page): string
+    {
+        preg_match_all('/@block\( ?\'(\w*?)\', ?\'(\N*?)\' ?\)/is', $page, $matches, PREG_SET_ORDER);
+        
+        foreach ($matches as $match) {
+            if (!array_key_exists($match[1], $this->blocks)) {
+                $this->blocks[$match[1]] = $match[2];
+            }
+
+            $page = str_replace($match[0], '', $page);
         }
 
         return $page;

--- a/src/Modello.php
+++ b/src/Modello.php
@@ -16,7 +16,6 @@ class Modello
     private array $handlers = [
         'handleIncludes',
         'handleBlocks',
-        'handleBlockInline',
         'handleHasBlock',
         'handleBlockMissing',
         'handleYields',
@@ -209,18 +208,10 @@ class Modello
     private function handleBlocks(string $page): string
     {
         preg_match_all('/@block\( ?\'(\w*?)\' ?\)(.*?)@endblock/is', $page, $matches, PREG_SET_ORDER);
+        preg_match_all('/@block\( ?\'(\w*?)\', ?\'(\N*?)\' ?\)/is', $page, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $match) {
-            if (!array_key_exists($match[1], $this->blocks)) {
-                $this->blocks[$match[1]] = '';
-            }
-
-            if (strpos($match[2], '@parent') === false) {
-                $this->blocks[$match[1]] = trim($match[2]);
-            } else {
-                $this->blocks[$match[1]] = trim(str_replace('@parent', $this->blocks[$match[1]], $match[2]));
-            }
-
+            $this->blocks[$match[1]] = trim($match[2]);
             $page = str_replace($match[0], '', $page);
         }
 
@@ -306,22 +297,6 @@ class Modello
         foreach ($matches as $match) {
             $replace = !array_key_exists($match[1], $this->blocks) ? $match[2] : '';
             $page = str_replace($match[0], $replace, $page);
-        }
-
-        return $page;
-    }
-
-    // Directive to do the same thing as @block but in one line with two strings
-    function handleBlockInline(string $page): string
-    {
-        preg_match_all('/@block\( ?\'(\w*?)\', ?\'(\N*?)\' ?\)/is', $page, $matches, PREG_SET_ORDER);
-        
-        foreach ($matches as $match) {
-            if (!array_key_exists($match[1], $this->blocks)) {
-                $this->blocks[$match[1]] = $match[2];
-            }
-
-            $page = str_replace($match[0], '', $page);
         }
 
         return $page;

--- a/src/Modello.php
+++ b/src/Modello.php
@@ -211,7 +211,7 @@ class Modello
         preg_match_all('/@block\( ?\'(\w*?)\', ?\'(\N*?)\' ?\)/is', $page, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $match) {
-            $this->blocks[$match[1]] = trim($match[2]);
+            $this->blocks[$match[1]] = $match[2];
             $page = str_replace($match[0], '', $page);
         }
 

--- a/src/Modello.php
+++ b/src/Modello.php
@@ -16,8 +16,7 @@ class Modello
     private array $handlers = [
         'handleIncludes',
         'handleBlocks',
-        'handleHasBlock',
-        'handleBlockMissing',
+        'handleBlockConditionals',
         'handleYields',
         'handleEchoes',
         'handleEscapedEchoes',
@@ -278,24 +277,17 @@ class Modello
 	}
 
     // A directive to test whether we have a block by a given key
-    function handleHasBlock(string $page): string
+    function handleBlockConditionals(string $page): string
     {
-        preg_match_all('/@hasblock\( ?\'(\w*?)\' ?\)(.*?)@endif/is', $page, $matches, PREG_SET_ORDER);
+        preg_match_all('/@hasblock\( ?\'(\w*?)\' ?\)(.*?)@endif/is', $page, $has, PREG_SET_ORDER);
+        preg_match_all('/@blockmissing\( ?\'(\w*?)\' ?\)(.*?)@endif/is', $page, $missing, PREG_SET_ORDER);
         
-        foreach ($matches as $match) {
+        foreach ($has as $match) {
             $replace = array_key_exists($match[1], $this->blocks) ? $match[2] : '';
             $page = str_replace($match[0], $replace, $page);
         }
-
-        return $page;
-    }
-
-    // Directive that does the opposite of @hasblock
-    function handleBlockMissing(string $page): string
-    {
-        preg_match_all('/@blockmissing\( ?\'(\w*?)\' ?\)(.*?)@endif/is', $page, $matches, PREG_SET_ORDER);
         
-        foreach ($matches as $match) {
+        foreach ($missing as $match) {
             $replace = !array_key_exists($match[1], $this->blocks) ? $match[2] : '';
             $page = str_replace($match[0], $replace, $page);
         }


### PR DESCRIPTION
- Adds the `@block('key', 'string')` syntax for one-line block directives (think titles for pages)
- Combines the new `@block` syntax handler with the block-style handler, so both are handled by one function
- Combines the handlers for the block conditionals `@hasblock` and `@blockmissing`
- Removes the undocumented `@parent` directive as the purpose and use was not clear, likely leftovers from legacy tags