### PR TITLE
Implement debug info

### DIFF
--- a/src/Modello.php
+++ b/src/Modello.php
@@ -9,12 +9,11 @@ class Modello
     private bool $cacheEnabled = true;
     private string $extension = '.mllo.php';
 
-    private int $renderTime = 0;
-    private int $templateCount = 0;
-    private int $blockCount = 0;
-    private bool $compiled = false;
-    private bool $recompiled = false;
-    private bool $usedCache = false;
+    private int $dbg_renderTime = 0;
+    private int $dbg_templateCount = 0;
+    private bool $dbg_compiled = false;
+    private bool $dbg_recompiled = false;
+    private bool $dbg_usedCache = false;
 
     // Stored blocks. Enables the @yield directive!
     private array $blocks = [];

--- a/src/Modello.php
+++ b/src/Modello.php
@@ -9,6 +9,13 @@ class Modello
     private bool $cacheEnabled = true;
     private string $extension = '.mllo.php';
 
+    private int $renderTime = 0;
+    private int $templateCount = 0;
+    private int $blockCount = 0;
+    private bool $compiled = false;
+    private bool $recompiled = false;
+    private bool $usedCache = false;
+
     // Stored blocks. Enables the @yield directive!
     private array $blocks = [];
 


### PR DESCRIPTION
This PR will take over for #8 for tracking
The goal is simply to add a variety of trackers for various actions during render
- how long in seconds the render took
- whether the view was compiled, recompiled, or pulled from cache
- allow access to all blocks registered
- getters for the viewpath, cachepath, cache enabled, and extension
- how many includes are handled in the render
- maybe an array containing all the view-level comments?